### PR TITLE
Replace callback comments with @impl

### DIFF
--- a/apps/web_delivery/lib/web_delivery.ex
+++ b/apps/web_delivery/lib/web_delivery.ex
@@ -2,20 +2,25 @@ defmodule WebDelivery do
   use Application
 
   alias WebDelivery.Endpoint
-
-  ## Callbacks
-
-  def start(_type, _args) do
-    import Supervisor.Spec
-
-    Supervisor.start_link [supervisor(Endpoint, [])],
-      strategy: :one_for_one,
-      name: WebDelivery.Supervisor
-  end
+  import Supervisor.Spec
 
   @spec config_change(keyword, keyword, [atom]) :: :ok
   def config_change(changed, _new, removed) do
     Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  @impl Application
+  def start(_type, _args) do
+    Supervisor.start_link children(),
+      strategy: :one_for_one,
+      name: WebDelivery.Supervisor
+  end
+
+  @spec children() :: [Supervisor.Spec.spec]
+  defp children do
+    [
+      supervisor(Endpoint, []),
+    ]
   end
 end

--- a/apps/web_delivery/web/channels/user_socket.ex
+++ b/apps/web_delivery/web/channels/user_socket.ex
@@ -3,9 +3,9 @@ defmodule WebDelivery.UserSocket do
 
   transport :websocket, Phoenix.Transports.WebSocket, timeout: 45_000
 
-  ## Callbacks
-
+  @impl Phoenix.Socket
   def connect(_params, socket), do: {:ok, socket}
 
+  @impl Phoenix.Socket
   def id(_socket), do: nil
 end

--- a/elixir_style_guide.md
+++ b/elixir_style_guide.md
@@ -24,7 +24,7 @@
     def foo(x, y), do: x * y
     ```
 
-- Place callbacks at the bottom of a module, marked with a `## Callbacks` separator comment.
+- Identify callback implementations with `@impl SomeModule`, replacing `SomeModule` with the name of the module that defines the callback.
 
 - Alias other modules directly under your app's namespace that are referenced within your module.
 


### PR DESCRIPTION
Why
---

`@impl` will act as comment before Elixir 1.5 and as compiler tag after

How
---

* Replace `## Callback` comments with `@impl` attributes
* Replace `## Callback` recommendation with `@impl` recommendation in style guide